### PR TITLE
Fix the viewer window resize gravity glitch.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1658,9 +1658,9 @@
       }
     },
     "@data-driven-forms/topology-viewer": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/topology-viewer/-/topology-viewer-0.0.3.tgz",
-      "integrity": "sha512-xXHMYn5d4j9caxPx8eTGs36p4yvgs6zamYBZZT7oxzFwqzWqJOqX9Fmesm8CVNPqTVj31npx+xOX+r8TnV2dSw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/topology-viewer/-/topology-viewer-0.0.4.tgz",
+      "integrity": "sha512-cQdMHk3lJuwCXbyFlSu7i7YAr0Os+/PhZ2KHrgwu39wa4yoGEECQFd+N+nywBs4/1DJe6D9sxM43bNnh2di+uw==",
       "requires": {
         "d3": "^5.9.7",
         "lodash": "^4.17.15"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.3",
     "@data-driven-forms/pf4-component-mapper": "^2.5.2",
-    "@data-driven-forms/topology-viewer": "0.0.3",
+    "@data-driven-forms/topology-viewer": "0.0.4",
     "@patternfly/react-core": "^4.18.5",
     "@redhat-cloud-services/frontend-components": "2.0.6",
     "@redhat-cloud-services/frontend-components-utilities": "2.0.5",


### PR DESCRIPTION
When the window was resized, the viewer simulation was restarted but the center of the gravity of the force-directed graph changes and god stronger, which caused the nodes to suddenly and very aggressively move towards the center of the SVG.

I've updated the viewer to not reset the simulation and only progress the simulation by one tick to recalculate the off-screen node counter.