### PR TITLE
Start with collapsed sources.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,5 @@
   "tabWidth": 2,
   "singleQuote": true,
   "jsxSingleQuote": false,
-  "printWidth": 160
+  "printWidth": 120
 }

--- a/src/api/ansible-tower.js
+++ b/src/api/ansible-tower.js
@@ -3,21 +3,34 @@ import { TOPOLOGICAL_INVETORY_API_BASE } from '../constants/api-constants';
 
 // level 0
 export const getSources = () => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources`);
-export const getServieCredentials = () => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_credentials`);
-export const getServiceCredentialTypes = () => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_credential_types`);
+export const getServieCredentials = () =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_credentials`);
+export const getServiceCredentialTypes = () =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_credential_types`);
 
 // level 1
-export const getServiceOfferings = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_offerings`);
-export const getServicePlans = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_plans`);
-export const getServiceInstance = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_instances`);
-export const getServiceInventories = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_inventories`);
-export const getServiceInstanceNodes = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_instance_nodes`);
-export const getServiceOfferingNodes = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_offering_nodes`);
+export const getServiceOfferings = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_offerings`);
+export const getServicePlans = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_plans`);
+export const getServiceInstance = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_instances`);
+export const getServiceInventories = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_inventories`);
+export const getServiceInstanceNodes = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_instance_nodes`);
+export const getServiceOfferingNodes = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/service_offering_nodes`);
 
 export const getSource = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}`);
-export const getServiceOffering = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_offerings/${id}`);
+export const getServiceOffering = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_offerings/${id}`);
 export const getServicePlan = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_plans/${id}`);
-export const getServiceInstanc = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_instances/${id}`);
-export const getServiceInventorie = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_inventories/${id}`);
-export const getServiceInstanceNode = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_instance_nodes/${id}`);
-export const getServiceOfferingNode = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_offering_nodes/${id}`);
+export const getServiceInstanc = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_instances/${id}`);
+export const getServiceInventorie = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_inventories/${id}`);
+export const getServiceInstanceNode = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_instance_nodes/${id}`);
+export const getServiceOfferingNode = (id) =>
+  getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/service_offering_nodes/${id}`);

--- a/src/api/entities-api.js
+++ b/src/api/entities-api.js
@@ -6,6 +6,8 @@ import { defaultSettings } from '../utilities/pagination';
 const api = getAxtionsInstace();
 
 export const getSources = (apiProps = { filter: '' }, options = defaultSettings) =>
-  api.get(`${SOURCES_API_BASE}/sources?filter[name][contains]=${apiProps.filter}&offset=${options.offset}&limit=${options.limit}`);
+  api.get(
+    `${SOURCES_API_BASE}/sources?filter[name][contains]=${apiProps.filter}&offset=${options.offset}&limit=${options.limit}`
+  );
 
 export const getVms = () => api.get(`${TOPOLOGICAL_INVETORY_API_BASE}/vms`).then(({ data }) => data);

--- a/src/components/tree/node.js
+++ b/src/components/tree/node.js
@@ -6,7 +6,8 @@ const NodeWrapper = styled(({ level, ...props }) => <div {...props} />)`
   padding-left: ${({ level }) => (level > 0 ? 24 : 0)}px;
 `;
 
-const DefaultRenderComponent = ({ title, level }) => React.createElement(`h${level + 1 <= 6 ? level + 1 : 6}`, {}, title);
+const DefaultRenderComponent = ({ title, level }) =>
+  React.createElement(`h${level + 1 <= 6 ? level + 1 : 6}`, {}, title);
 
 DefaultRenderComponent.propTypes = {
   title: PropTypes.node.isRequired,

--- a/src/pages/detail.js
+++ b/src/pages/detail.js
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from 'react';
 
-import { Card, CardTitle, CardBody, TextContent, TextListItem, TextListItemVariants, TextListVariants, TextList } from '@patternfly/react-core';
+import {
+  Card,
+  CardTitle,
+  CardBody,
+  TextContent,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+  TextList,
+} from '@patternfly/react-core';
 
 import {
   getSource,

--- a/src/pages/tree-view.js
+++ b/src/pages/tree-view.js
@@ -63,12 +63,24 @@ const TreeView = () => {
       .then((sources) => {
         const promises = sources.map(({ id }) => {
           const subCollections = [
-            getServiceOfferings(id).then((data) => dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-offerings', data } })),
-            getServicePlans(id).then((data) => dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-plans', data } })),
-            getServiceInstance(id).then((data) => dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-instances', data } })),
-            getServiceInventories(id).then((data) => dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-inventories', data } })),
-            getServiceInstanceNodes(id).then((data) => dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-instance-nodes', data } })),
-            getServiceOfferingNodes(id).then((data) => dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-offering-nodes', data } })),
+            getServiceOfferings(id).then((data) =>
+              dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-offerings', data } })
+            ),
+            getServicePlans(id).then((data) =>
+              dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-plans', data } })
+            ),
+            getServiceInstance(id).then((data) =>
+              dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-instances', data } })
+            ),
+            getServiceInventories(id).then((data) =>
+              dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-inventories', data } })
+            ),
+            getServiceInstanceNodes(id).then((data) =>
+              dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-instance-nodes', data } })
+            ),
+            getServiceOfferingNodes(id).then((data) =>
+              dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'service-offering-nodes', data } })
+            ),
           ];
           return Promise.all(subCollections).then(() => setLoading(false));
         });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,4 +1,6 @@
-import ReducerRegistry, { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
+import ReducerRegistry, {
+  applyReducerHash,
+} from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
 import promiseMiddleware from 'redux-promise-middleware';
 import sourcesReducer, { sourcesInitialState } from './reducers/sources-reducer';
 


### PR DESCRIPTION
Before ansible sources started with 6 expanded nodes (one per each category). That can cause some initial simulation clutter. Now the simulation starts only with collapsed source nodes and categories have to be expanded to prevent initial jitter.