### PR TITLE
Fixed topology simulation memory leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1658,9 +1658,9 @@
       }
     },
     "@data-driven-forms/topology-viewer": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/topology-viewer/-/topology-viewer-0.0.4.tgz",
-      "integrity": "sha512-cQdMHk3lJuwCXbyFlSu7i7YAr0Os+/PhZ2KHrgwu39wa4yoGEECQFd+N+nywBs4/1DJe6D9sxM43bNnh2di+uw==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/topology-viewer/-/topology-viewer-0.0.5.tgz",
+      "integrity": "sha512-v44lKcsxljm2XEe1PrIR1laP33fxnVzX/Dj87hPeQbVaLDEZJh6s0R/Gx7gf9JdwevIBfZQQG+MngH0i3BwzUA==",
       "requires": {
         "d3": "^5.9.7",
         "lodash": "^4.17.15"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.3",
     "@data-driven-forms/pf4-component-mapper": "^2.5.2",
-    "@data-driven-forms/topology-viewer": "0.0.4",
+    "@data-driven-forms/topology-viewer": "0.0.5",
     "@patternfly/react-core": "^4.18.5",
     "@patternfly/react-icons": "^4.3.5",
     "@redhat-cloud-services/frontend-components": "2.0.6",


### PR DESCRIPTION
The topology component was causing memory leaks
- did not remove resize window listener
- did not stop d3 force simulation

This is fixed in `v0.0.5`