### PR TITLE
Fix treeview for amazon

### DIFF
--- a/src/api/amazon.js
+++ b/src/api/amazon.js
@@ -3,7 +3,7 @@ import { TOPOLOGICAL_INVETORY_API_BASE } from '../constants/api-constants';
 
 // level 1
 
-export const getVms = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/vms`);
+export const getVms = (id) => getAxtionsInstace().get(`${TOPOLOGICAL_INVETORY_API_BASE}/sources/${id}/vms?limit=4`);
 
 // level 2 vms / id / type
 

--- a/src/components/tree/node.js
+++ b/src/components/tree/node.js
@@ -35,6 +35,7 @@ const Node = ({ title, level, children, render, ...node }) => {
             <AngleDownIcon />
           </Button>
         )}
+        {children.length === 0 && <span style={{ marginLeft: 46 }} />}
         {render({ title, level, ...node })}
       </div>
       {open && children.map((node) => <Node level={level + 1} key={node.id} _ {...node} render={render} />)}

--- a/src/pages/tree-view.js
+++ b/src/pages/tree-view.js
@@ -22,8 +22,8 @@ import {
   getSecurityGroups,
   getTags,
   getNetworkAdapters,
-  getPrivateIpAddresses,
-  getPublicIpAddresses,
+  // getPrivateIpAddresses,
+  // getPublicIpAddresses,
 } from '../api/amazon';
 
 const promisesMapper = (id, typeName, dispatch) => {

--- a/src/pages/tree-view.js
+++ b/src/pages/tree-view.js
@@ -67,12 +67,12 @@ const promisesMapper = (id, typeName, dispatch) => {
                 getNetworkAdapters(id).then((data) =>
                   dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'network-adapters', data } })
                 ),
-                getPrivateIpAddresses(id).then((data) =>
+                /*getPrivateIpAddresses(id).then((data) =>
                   dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'private-ip-addresses', data } })
                 ),
                 getPublicIpAddresses(id).then((data) =>
                   dispatch({ type: UPDATE_NODE, id, subCollections: { type: 'public-ip-addresses', data } })
-                ),
+                ),*/
               ];
 
               return Promise.all(subCollections);
@@ -108,7 +108,7 @@ function createNodeData(node, type) {
   return {
     ...copy,
     id: node.id,
-    title: node.name || node.id,
+    title: node.name || node.id || node[Object.keys(node)[0]],
     ...(type && { type }),
     ...(node.entityType && { type: node.entityType }),
     nodeData: node,
@@ -134,16 +134,18 @@ const TreeView = () => {
     if (!structure?.data || structure?.data?.length === 0) {
       setLoading(true);
       Promise.all([getSources(), getSourceTypes()])
-        .then(async ([data, sourceTypes]) => {
-          const sourcesTypes = await getSourcesTypes(data.data.map(({ id }) => id));
+        .then(async ([sources, sourceTypes]) => {
+          const data = Array.isArray(sources.data) ? sources.data : [sources];
 
-          const modifiedData = data.data.map((d) => ({
+          const sourcesTypes = await getSourcesTypes(data.map(({ id }) => id));
+
+          const modifiedData = data.map((d) => ({
             ...d,
             entityType: 'sources',
-            source_type_id: sourcesTypes.data.sources.find(({ id }) => id === d.id).source_type_id,
+            source_type_id: sourcesTypes.data.sources.find(({ id }) => id === d.id)?.source_type_id,
             source_type_name: sourceTypes.data.find(
-              ({ id }) => id === sourcesTypes.data.sources.find(({ id }) => id === d.id).source_type_id
-            ).name,
+              ({ id }) => id === sourcesTypes.data.sources.find(({ id }) => id === d.id)?.source_type_id
+            )?.name,
           }));
 
           dispatch({
@@ -166,6 +168,7 @@ const TreeView = () => {
         });
     }
   }, []);
+
   if (loading) {
     return <CardLoader />;
   }

--- a/src/store/reducers/sources-reducer.js
+++ b/src/store/reducers/sources-reducer.js
@@ -12,13 +12,23 @@ export const sourcesInitialState = {
 const setData = (state, { payload }) => ({ ...state, ...payload });
 
 const updateNested = (data, id, subCollections) =>
-  data.map((node) =>
-    node.id === id
+  data.map((node) => {
+    if (node.data && node.data.data) {
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          data: updateNested(node.data.data, id, subCollections),
+        },
+      };
+    }
+
+    return node.id === id
       ? { ...node, subCollections: [...(node.subCollections ? node.subCollections : []), subCollections] }
       : node.subCollections
       ? { ...node, subCollections: updateNested(node.subCollections, id, subCollections) }
-      : node
-  );
+      : node;
+  });
 
 const updateNode = ({ data, ...state }, { id, subCollections }) => ({
   ...state,


### PR DESCRIPTION
- There are no endpoints for private/public ipaddresses
- update_node function was not able to handle subcollections strucutres
- empty space to align nodes without children
- when there is no name/id a first key of the object is used as a title

Also limits VM to 4.. why? because otherwise it creates hundreds of requests now. :D 

- updated tree building to allow changing url `/sources` to `/sources/${id}` to test just one specific source