### PR TITLE
Allow to switch between tree/topo views

### DIFF
--- a/src/components/view-switcher.js
+++ b/src/components/view-switcher.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ToggleGroupItem, ToggleGroup } from '@patternfly/react-core';
+import { Link, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { paths } from '../routes';
+
+const StyledLink = styled(Link)`
+  color: inherit;
+  text-decoration: none;
+`;
+
+const ViewSwitcher = (props) => {
+  const { pathname } = useLocation();
+
+  return (
+    <ToggleGroup {...props}>
+      <StyledLink to={paths.treeView}>
+        <ToggleGroupItem isSelected={pathname === paths.treeView}>Tree view</ToggleGroupItem>
+      </StyledLink>
+      <StyledLink to={paths.topologyView}>
+        <ToggleGroupItem isSelected={pathname === paths.topologyView}>Topology view</ToggleGroupItem>
+      </StyledLink>
+    </ToggleGroup>
+  );
+};
+
+export default ViewSwitcher;

--- a/src/store/action-types/sources-action-types.js
+++ b/src/store/action-types/sources-action-types.js
@@ -11,3 +11,5 @@ export const LOAD_DETAIL_FAILED = `${prefix}LOAD_DETAIL_FAILED`;
 
 export const CLOSE_DETAIL = `${prefix}CLOSE_DETAIL`;
 export const OPEN_DETAIL = `${prefix}OPEN_DETAIL`;
+
+export const CLICK_ON_NODE = `${prefix}CLICK_ON_NODE`;

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -7,6 +7,7 @@ import {
   LOAD_DETAIL_PENDING,
   OPEN_DETAIL,
   CLOSE_DETAIL,
+  CLICK_ON_NODE,
 } from './action-types/sources-action-types';
 
 import { loadSources } from '../api/topology-viewer-api';
@@ -83,4 +84,9 @@ export const loadItemDetail = (name, id, nodeName) => async (dispatch, getState)
 
 export const closeDetailDrawer = () => ({
   type: CLOSE_DETAIL,
+});
+
+export const clickOnNode = (name, id) => ({
+  type: CLICK_ON_NODE,
+  payload: { node: `${name}-${id}` },
 });

--- a/src/store/reducers/sources-reducer.js
+++ b/src/store/reducers/sources-reducer.js
@@ -6,6 +6,7 @@ import {
   LOAD_DETAIL_PENDING,
   CLOSE_DETAIL,
   OPEN_DETAIL,
+  CLICK_ON_NODE,
 } from '../action-types/sources-action-types';
 
 export const sourcesInitialState = {
@@ -19,6 +20,7 @@ export const sourcesInitialState = {
     node: undefined,
     name: undefined,
   },
+  openedNodes: [],
 };
 
 const loadData = (state, { payload: { sources } }) => ({
@@ -66,6 +68,13 @@ const openDetail = (state, { payload }) => ({
   },
 });
 
+const clickOnNode = (state, { payload }) => ({
+  ...state,
+  openedNodes: state.openedNodes.includes(payload.node)
+    ? state.openedNodes.filter((node) => node !== payload.node)
+    : [...state.openedNodes, payload.node],
+});
+
 export default {
   [LOAD_DATA]: loadData,
   [LOAD_SOURCE_TYPES]: loadSourceTypes,
@@ -74,4 +83,5 @@ export default {
   [LOAD_DETAIL_PENDING]: loadDetailPending,
   [CLOSE_DETAIL]: closeDetail,
   [OPEN_DETAIL]: openDetail,
+  [CLICK_ON_NODE]: clickOnNode,
 };


### PR DESCRIPTION
- replaces breadcrumbs with toggle group
- allows to switch between tree/topo and to not lost opened nodes


![ezgif com-optimize (1)](https://user-images.githubusercontent.com/32869456/94808779-ec379780-03f1-11eb-8081-9b3fb52b9bc5.gif)
